### PR TITLE
Fix errors only absolute URLs are supported 

### DIFF
--- a/src/pages/books/[bookId].tsx
+++ b/src/pages/books/[bookId].tsx
@@ -7,10 +7,9 @@ import { Layout } from "../../components";
 import type { Book } from "../../types";
 
 function useGetBookData(bookId) {
-  const { data, error } = useSWR(
-    `${process.env.NEXT_PUBLIC_API_URL}/books/${bookId}`,
-    fetcher
-  );
+  const URL = process.env.NEXT_PUBLIC_API_URL;
+
+  const { data, error } = useSWR(`${URL}/books/${bookId}`, fetcher);
 
   return {
     data: data,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,7 +33,9 @@ export default function Home({ data }: HomeProps) {
 }
 
 export async function getStaticProps() {
-  const res = await fetch(`${process.env.API_URL}/books`);
+  const URL = process.env.NEXT_PUBLIC_API_URL;
+
+  const res = await fetch(`${URL}/books`);
   const data = await res.json();
   return {
     props: {


### PR DESCRIPTION
Fix errors only absolute URLs are supported when GET data through API using useSWR. 